### PR TITLE
Fix nmos18 default connection value

### DIFF
--- a/pymacros/sky130_pcells/nmos18.py
+++ b/pymacros/sky130_pcells/nmos18.py
@@ -74,7 +74,7 @@ class NMOS18(pya.PCellDeclarationHelper):
         self.param("dsa", self.TypeInt,
                    "drain and source number of contacts", default=1)
         connection_option = self.param(
-            "connection", self.TypeString, "Connection Option", default="Connection Up")
+            "connection", self.TypeString, "Connection Option", default=0)
         connection_option.add_choice("Connection Up", 0)
         connection_option.add_choice("Connection Down", 1)
         connection_option.add_choice("Alternate connection", 2)


### PR DESCRIPTION
This fixes a bug where it tries to cast the default value to an integer

Steps to reproduce: 

https://user-images.githubusercontent.com/168609/173038300-1a3e3478-2a7b-4515-8b9b-e614c6eb3f1a.mp4

